### PR TITLE
Add flex property to images

### DIFF
--- a/src/amplify.scss
+++ b/src/amplify.scss
@@ -8,6 +8,7 @@
 .js-amplify[aria-expanded="true"] {
   will-change: max-width;
   transition: max-width 0.2s ease-in-out;
+  flex: 0 0 auto;
 }
 
 .js-amplify[aria-expanded="false"] {


### PR DESCRIPTION
This fixes #2 for Firefox users.